### PR TITLE
feat: add title and description section of the learnabout page

### DIFF
--- a/src/components/BetaSignupCard.tsx
+++ b/src/components/BetaSignupCard.tsx
@@ -1,5 +1,5 @@
 "use client";
-import SignUpButton from "./SignUpButton";
+import SignUpButton from "../views/Home/components/SignUpButton";
 import { useRef, useState } from "react";
 
 export default function BetaSignupSection() {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,7 +7,7 @@ const NAV_ITEMS = [
   { label: "Home", href: "/" },
   { label: "Our Story", href: "/#our-story" },
   { label: "Learn More", href: "/learn-more" },
-  { label: "Blog", href: "/blog" },
+  { label: "Contact", href: "/contact" },
   { label: "Beta Sign Up 🚀", href: "/beta-sign-up" },
 ];
 
@@ -36,7 +36,7 @@ export function Header() {
                 key={item.href}
                 href={item.href}
                 scroll={false}
-                className="px-6.5 py-2.5 text-[18px] font-bold hover:text-[var(--color-main)]"
+                className="px-6.5 py-2.5 text-[18px] font-bold hover:text-[var(--color-main)] focus:outline-none"
                 onClick={(e) => {
                   if (!isOurStory) return;
 

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -1,8 +1,8 @@
-import { HeroSection } from "./components/HeroSection";
-import { OurStorySection } from "./components/OurStorySection";
-import BetaSignUpSection from "./components/BetaSignupSection";
+import { HeroSection } from "@/views/Home/components/HeroSection";
+import { OurStorySection } from "@/views/Home/components/OurStorySection";
+import BetaSignUpSection from "@/components/BetaSignupCard";
 import { ScrollManager } from "@/components/behavior/ScrollManager";
-import { VideoSection } from "./components/VideoSection";
+import { VideoSection } from "@/views/Home/components/VideoSection";
 
 export default function HomeView() {
   return (

--- a/src/views/LearnMore/components/BetaSignupSection.tsx
+++ b/src/views/LearnMore/components/BetaSignupSection.tsx
@@ -1,0 +1,11 @@
+import BetaSignUpCard from "@/components/BetaSignupCard";
+
+export function BetaSignUpSection() {
+  return (
+    <div className="justify-center flex flex-col">
+      <h1>LinkedSpaces Beta</h1>
+      <p>Sign Up and Thank Yourself Later!</p>
+      <BetaSignUpCard />
+    </div>
+  );
+}

--- a/src/views/LearnMore/components/DescriptionBlock.tsx
+++ b/src/views/LearnMore/components/DescriptionBlock.tsx
@@ -1,0 +1,50 @@
+type DescriptionBlockProps = {
+  title: string;
+  description: string;
+  videoSrc: string;
+  reverse?: boolean;
+};
+
+export function DescriptionBlock({
+  title,
+  description,
+  videoSrc,
+  reverse = false,
+}: DescriptionBlockProps) {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 lg:gap-16 items-stretch">
+      {/* Text */}
+      <div className={`flex ${reverse ? "lg:order-2" : "lg:order-1"}`}>
+        {/* 이 래퍼가 '비디오 높이'를 따라가고, 그 안에서 텍스트를 세로 중앙으로 */}
+        <div className="w-full flex flex-col justify-center text-center gap-4 text-black whitespace-pre-line lg:min-h-[560px]">
+          <h2 className="text-[38px] font-semibold [font-family:var(--font-poppins)]">
+            {title}
+          </h2>
+          <p className="text-xl font-bold leading-[180%]">{description}</p>
+        </div>
+      </div>
+
+      {/* Video */}
+
+      <div
+        className={`${reverse ? "lg:order-1" : "lg:order-2"} lg:flex lg:justify-end`}
+      >
+        <div className="w-full flex justify-center lg:justify-end">
+          <div className="relative lg:w-[902px] lg:h-[808px] w-full overflow-hidden rounded-2xl bg-white border-0 outline-none ring-0 shadow-none">
+            <video
+              className="h-full w-full object-cover bg-white border-0 outline-none ring-0 shadow-none pointer-events-none scale-[1.01]"
+              autoPlay
+              loop
+              muted
+              playsInline
+              controls={false}
+              preload="metadata"
+            >
+              <source src={videoSrc} type="video/mp4" />
+            </video>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/views/LearnMore/components/DescriptionSection.tsx
+++ b/src/views/LearnMore/components/DescriptionSection.tsx
@@ -1,0 +1,40 @@
+import { DescriptionBlock } from "./DescriptionBlock";
+
+const DESCRIPTION_BLOCKS = [
+  {
+    title: "Mission",
+    description:
+      "To turn moments into lasting memories while\n seamlessly organizing and sharing them with your\n private network.",
+    videoSrc: "/videos/recap-blog.mp4",
+    videoAlt: "Studio mode demo video",
+    reverse: false,
+  },
+  {
+    title: "Vision",
+    description:
+      "To be the ultimate platform for travelers, transforming how places are saved, organized, and rediscovered, while fostering a trusted network to share and gain personalized recommendations.",
+    videoSrc: "/videos/ls-ig-content.mp4",
+    videoAlt: "AI assistant demo video",
+    reverse: true,
+  },
+];
+
+export function DescriptionSection() {
+  return (
+    <section id="our-story" className="w-full scroll-mt-20">
+      <div className="mx-auto px-6 py-20 lg:px-50">
+        <div className="space-y-24">
+          {DESCRIPTION_BLOCKS.map((block) => (
+            <DescriptionBlock
+              key={block.title}
+              title={block.title}
+              description={block.description}
+              videoSrc={block.videoSrc}
+              reverse={block.reverse}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/views/LearnMore/components/TitleSection.tsx
+++ b/src/views/LearnMore/components/TitleSection.tsx
@@ -1,0 +1,17 @@
+export function TitleSection() {
+  return (
+    <div className="justify-center items-center mt-[88px] mb-[70px] flex flex-col">
+      <h2 className="font-semibold text-2xl [font-family:var(--font-poppins)]">
+        Who Are We
+      </h2>
+      <h1 className="text-[56px] font-semibold [font-family:var(--font-poppins)]">
+        LinkedSpaces
+      </h1>
+      <h2 className="text-2xl font-bold text-center leading-[180%] mt-7">
+        LinkedSpaces is your travel companion! Easily capture, organize, and
+        relive
+        <br /> your adventures while sharing your stories effortlessly.
+      </h2>
+    </div>
+  );
+}

--- a/src/views/LearnMore/index.tsx
+++ b/src/views/LearnMore/index.tsx
@@ -1,3 +1,13 @@
+import { TitleSection } from "@/views/LearnMore/components/TitleSection";
+import { DescriptionSection } from "@/views/LearnMore/components/DescriptionSection";
+import { BetaSignUpSection } from "@/views/LearnMore/components/BetaSignupSection";
+
 export default function LearnMoreView() {
-  return <p>about linkedspaces</p>;
+  return (
+    <div>
+      <TitleSection />
+      <DescriptionSection />
+      <BetaSignUpSection />
+    </div>
+  );
 }


### PR DESCRIPTION
**Summary**

- Implemented the Learn More page structure and main sections.
- Added reusable DescriptionBlock/DescriptionSection components and enabled video-based media rendering (auto-play, loop, muted, no controls).
- Fixed multiple UI/styling details (typography, alignment, spacing) and cleaned up imports/exports.

**What changed**

- Created/updated Learn More components:
  - TitleSection
  - DescriptionSection
  - DescriptionBlock (switched media from image to video)
  - Updated routing/page wiring for Learn More view.

- Improved styling:
